### PR TITLE
Add Evernote tags to Teedy, Truncate Title and Description to match Teedy limits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/1set/gut v0.0.0-20201117175203-a82363231997
 	github.com/alexflint/go-arg v1.4.1
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
-	github.com/go-resty/resty/v2 v2.6.0
+	github.com/go-resty/resty/v2 v2.7.0
 	github.com/jarcoal/httpmock v1.0.8
 	github.com/stretchr/testify v1.7.0
 	github.com/wormi4ok/evernote2md v0.16.1


### PR DESCRIPTION
1. Evernote tags were discarded when adding to Teedy. Added the capability to check if the Evernote tag already exists, if not then add it to Teedy, and the document. 

This relies on tags being Teedy compliant (no spaces or colons). I've created a Python routine to make the tags Teedy compliant by replacing the spaces with underscores, and the colons with a dash at https://github.com/oz-glenn/evernote_tag_converter

2. The import kept failing with code 200 from Teedy. This was because either Title or Details were too long on some Evernotes. Added code to enforce the limits (length 100 for Titles, 4000 for details) by truncation to the nearest word.

3. The build failed until I updated resty v2 in go.mod to version 2.7.0.

I'm a lapsed C++ programmer, last programming professionally in the 90s. I've been in an unrelated field since then and this is my first attempt at go. I hope it's elegant enough :)